### PR TITLE
(feat) Streaming endpoint fix and Prompt Delete button

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -593,9 +593,9 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -18,6 +18,7 @@ hyper = "1.6.0"
 jsonschema = "0.29.0"
 jsonwebtoken = "9.3.1"
 moka = { version = "0.12.8", features = ["future"] }
+
 # openrouter_api = "0.1.3"
 # openrouter_api = { path="../../openrouter_api" }
 openrouter_api = { git="https://github.com/danwritecode/openrouter_api" }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -26,7 +26,7 @@ use controllers::{
         get_eval_runs_by_prompt_version, update_eval_run_score,
     },
     prompts::{
-        api_completions, api_completions_stream, create_prompt, delete_prompt, get_prompt, 
+        api_completions, create_prompt, delete_prompt, get_prompt, 
         get_prompt_versions, list_prompts, set_active_version, update_prompt
     }, 
     schema::validate_schema,
@@ -63,7 +63,6 @@ async fn main() -> Result<()> {
     // API routes that require API key auth
     let api_routes = Router::new()
         .route("/chat/completions", post(api_completions))
-        .route("/chat/completions/stream", post(api_completions_stream))
         .layer(axum_middleware::from_fn_with_state(
             app_state.clone(),
             auth::api_key_middleware,
@@ -88,9 +87,6 @@ async fn main() -> Result<()> {
         .route("/ui/prompts/{id}/prompt-evals", get(get_eval_test_by_prompt))
         .route("/ui/prompts/{id}/performance", get(get_eval_performance_by_prompt_id))
         .route("/ui/prompts/execute", post(api_completions))
-        .route("/ui/prompts/execute/stream", post(api_completions_stream))
-        .route("/ui/prompts/execute/chat", post(api_completions))
-        .route("/ui/prompts/execute/chat/stream", post(api_completions_stream))
         .route("/ui/prompt-evals", post(create_eval_test))
         .route("/ui/prompt-evals/{id}", get(get_eval_test_by_id).put(update_eval_test).delete(delete_eval_test))
         .route("/ui/prompt-eval-runs/{prompt_id}/version/{prompt_version_id}", post(execute_eval_run).get(get_eval_runs_by_prompt_version))

--- a/ui/components/global/primary-button.vue
+++ b/ui/components/global/primary-button.vue
@@ -29,7 +29,7 @@ defineProps({
     default: 'md'
   },
   buttonType: {
-    type: String as () => 'default' | 'primary' | 'primary-inverse' | 'secondary' | 'success' | 'error',
+    type: String as () => 'default' | 'primary' | 'primary-inverse' | 'secondary' | 'success' | 'error' | 'danger',
     default: 'default'
   },
   htmlType: {
@@ -52,6 +52,7 @@ const typeClasses = {
   'primary-inverse': 'border-black bg-transparent text-black hover:bg-neutral-100 dark:border-white dark:text-white dark:hover:bg-neutral-800',
   'secondary': 'border-neutral-300 bg-transparent text-neutral-700 hover:bg-neutral-50 dark:border-neutral-600 dark:text-neutral-300 dark:hover:bg-neutral-800',
   'success': 'border-green-600 bg-transparent text-green-600 hover:bg-green-50 dark:border-green-400 dark:text-green-400 dark:hover:bg-green-900/30',
-  'error': 'border-red-600 bg-transparent text-red-600 hover:bg-red-50 dark:border-red-400 dark:text-red-400 dark:hover:bg-red-900/30'
+  'error': 'border-red-600 bg-transparent text-red-600 hover:bg-red-50 dark:border-red-400 dark:text-red-400 dark:hover:bg-red-900/30',
+  'danger': 'border-red-600 bg-red-600 text-white hover:bg-red-700 dark:border-red-500 dark:bg-red-500 dark:hover:bg-red-600'
 };
 </script>

--- a/ui/components/prompts/add-edit.vue
+++ b/ui/components/prompts/add-edit.vue
@@ -302,6 +302,14 @@
           Cancel
         </PrimaryButton>
         <PrimaryButton
+          v-if="mode === 'edit'"
+          buttonType="danger"
+          size="sm"
+          @click="handleDelete()"
+        >
+          Delete
+        </PrimaryButton>
+        <PrimaryButton
           buttonType="primary"
           size="sm"
           :disabled="!isFormValid"
@@ -331,6 +339,7 @@ const emit = defineEmits<{
   "handle-cancel": [];
   "handle-create": [prompt: PromptCreateDTO];
   "handle-update": [prompt: PromptUpdateDTO];
+  "handle-delete": [id: number];
 }>();
 
 // Initialize form values from props
@@ -568,6 +577,14 @@ watch(jsonMode, (newVal) => {
     schemaValidationErrors.value = [];
   }
 });
+
+const handleDelete = () => {
+  if (props.prompt?.id) {
+    if (confirm(`Are you sure you want to delete the prompt "${props.prompt.key}"? This action cannot be undone.`)) {
+      emit("handle-delete", props.prompt.id);
+    }
+  }
+};
 
 const handleSubmit = async () => {
   // If JSON mode is enabled with a schema, validate it immediately before proceeding

--- a/ui/components/prompts/chat-test.vue
+++ b/ui/components/prompts/chat-test.vue
@@ -272,8 +272,8 @@ async function sendMessage() {
   streamingResponse.value = '';
   
   try {
-    // Create SSE connection for streaming using the OpenAI-compatible API
-    const source = new SSE(`/v1/ui/prompts/execute/chat/stream`, {
+    // Create SSE connection for streaming using the unified OpenAI-compatible API
+    const source = new SSE(`/v1/ui/prompts/execute`, {
       headers: { 'Content-Type': 'application/json' },
       payload: JSON.stringify({
         model: props.prompt.key,

--- a/ui/pages/prompts.vue
+++ b/ui/pages/prompts.vue
@@ -49,6 +49,7 @@
               @handle-cancel="mode = 'view'"
               @handle-create="handleCreate"
               @handle-update="handleUpdate"
+              @handle-delete="handleDelete"
             />
             <PromptsAddEdit 
               v-if="mode === 'new'" 
@@ -127,6 +128,7 @@ const {
   prompts, 
   createPrompt,
   updatePrompt,
+  deletePrompt,
   loading: promptsLoading,
   fetchPrompts 
 } = usePrompts();
@@ -163,6 +165,24 @@ async function handleUpdate(payload: PromptUpdateDTO) {
     mode.value = "view"
   } catch(e) {
     console.error(e)
+  }
+}
+
+async function handleDelete(id: number) {
+  try {
+    console.log(`Deleting prompt with ID: ${id}`)
+    await deletePrompt(id)
+    console.log('Deletion completed, updating UI...')
+    
+    // Fetch prompts again to ensure we have the latest data
+    await fetchPrompts()
+    
+    // Set selectedPrompt to the first prompt in the list or null if there are no prompts
+    console.log(`Prompts after deletion: ${prompts.value.length}`)
+    selectedPrompt.value = prompts.value.length > 0 ? prompts.value[0] : null
+    mode.value = "view"
+  } catch(e) {
+    console.error('Error deleting prompt:', e)
   }
 }
 


### PR DESCRIPTION
## Description

This PR introduces **prompt deletion** functionality and unifies the OpenAI-compatible completions API endpoint for both streaming and non-streaming requests.

---

### Backend

- **Prompt Deletion**
  - Adds a transactional, multi-step deletion process in `PromptRepository::delete_prompt` to ensure all related data (prompt versions, tool associations, evals, eval runs, and logs) is cleaned up.
  - Handles circular references by nulling `current_prompt_version_id` before deletion.
  - Controller now logs actions and removes the prompt from cache after deletion.

- **Completions API**
  - Unifies `/chat/completions` endpoint to handle both streaming and non-streaming requests via a single endpoint, using the `stream` flag in the payload.
  - Removes all `/stream` endpoints from the router.
  - Introduces a `CompletionResponse` enum for ergonomic Axum response handling.

---

### Frontend

- **Prompt Deletion**
  - Adds a "Delete" button to the prompt edit dialog, styled as a "danger" button.
  - Prompts for confirmation before deletion.
  - Updates the local prompt list and UI after deletion.
  - Adds robust error handling and logging.

- **Completions API**
  - All calls to `/execute/chat` and `/execute/chat/stream` are replaced with the unified `/execute` endpoint, with `stream: true/false` in the payload.
  - SSE connections now use the unified endpoint.

- **Styling**
  - Adds a new `danger` button type to `primary-button.vue` for destructive actions.

---

### Other

- Adds useful logs for debugging prompt deletion.
- Improves error handling and user feedback throughout.

---