### PR TITLE
(fix) Skipping `json_schema` serialization when None

### DIFF
--- a/backend/src/common/types/chat_request.rs
+++ b/backend/src/common/types/chat_request.rs
@@ -39,6 +39,7 @@ pub struct ChatCompletionRequestResponseFormat {
     /// Currently only supports "json_object" as per OpenAI spec
     #[serde(rename = "type")]
     pub format_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub json_schema: Option<ChatCompletionRequestJsonSchema>
 }
 


### PR DESCRIPTION
## Description 
We were including "json_schema" in the serialized json even when we weren't in json_schema mode and only in json mode. This was causing some models to complain that json_schema was not supported when we were just trying to use plain json mode. 