### PR TITLE
(fix) Tool message type added

### DIFF
--- a/backend/src/common/types/chat_request.rs
+++ b/backend/src/common/types/chat_request.rs
@@ -71,6 +71,10 @@ pub enum ChatCompletionRequestMessage{
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
     },
+    Tool { 
+        content: String,
+        tool_call_id: String
+    },
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -125,6 +129,7 @@ impl ChatCompletionRequestMessage {
             ChatCompletionRequestMessage::System { content, .. } => content,
             ChatCompletionRequestMessage::User { content, .. } => content,
             ChatCompletionRequestMessage::Assistant { content, .. } => content,
+            ChatCompletionRequestMessage::Tool { content, .. } => content,
         }
     }
 
@@ -134,6 +139,7 @@ impl ChatCompletionRequestMessage {
             ChatCompletionRequestMessage::System { name, .. } => name.as_deref(),
             ChatCompletionRequestMessage::User { name, .. } => name.as_deref(),
             ChatCompletionRequestMessage::Assistant { name, .. } => name.as_deref(),
+            _ => None
         }
     }
 
@@ -143,6 +149,7 @@ impl ChatCompletionRequestMessage {
             ChatCompletionRequestMessage::System { .. } => "system",
             ChatCompletionRequestMessage::User { .. } => "user",
             ChatCompletionRequestMessage::Assistant { .. } => "assistant",
+            ChatCompletionRequestMessage::Tool { .. } => "tool",
         }
     }
 


### PR DESCRIPTION
Tool message type is a possible message type as a response from a tool call. 

![image](https://github.com/user-attachments/assets/1adad8e0-3e6a-476a-91f6-493caa8974c5)
